### PR TITLE
fix: deduplicate fields with similar arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,10 @@ function generateQuery(name, parentType) {
 
       const args = field.args.map((arg) => {
         let varName = variableExists(arg.name)
-          ? camelCase(parentFields.map((field) => field.name).concat(arg.name))
+          ? camelCase(parentFields.map((field) => field.name)
+            .concat(name)
+            .concat(arg.name)
+          )
           : arg.name;
 
         if (variableExists(varName)) {


### PR DESCRIPTION
This creates some long ass argument names but fixes duplicate argument bug when query is like this
```graphql
query {
  getThing(pagination) {
    field1(pagination)
    field2(pagination)
  }
}
```

Ideally we would fix the variable exists check